### PR TITLE
CH4 - packer build provisioners errors

### DIFF
--- a/chapter4/distributed/master/setup.sh
+++ b/chapter4/distributed/master/setup.sh
@@ -23,6 +23,7 @@ chown -R jenkins:jenkins /var/lib/jenkins/.ssh/id_rsa
 echo "Configure Jenkins"
 mkdir -p /var/lib/jenkins/init.groovy.d
 mv /tmp/scripts/*.groovy /var/lib/jenkins/init.groovy.d/
+chown -R jenkins:jenkins /var/lib/jenkins/init.groovy.d
 mv /tmp/config/jenkins /etc/sysconfig/jenkins
 chmod +x /tmp/config/install-plugins.sh
 bash /tmp/config/install-plugins.sh

--- a/chapter4/distributed/master/setup.sh
+++ b/chapter4/distributed/master/setup.sh
@@ -22,8 +22,8 @@ chown -R jenkins:jenkins /var/lib/jenkins/.ssh/id_rsa
 
 echo "Configure Jenkins"
 mkdir -p /var/lib/jenkins/init.groovy.d
-mv /tmp/*.groovy /var/lib/jenkins/init.groovy.d/
-mv /tmp/jenkins /etc/sysconfig/jenkins
-chmod +x /tmp/install-plugins.sh
-bash /tmp/install-plugins.sh
+mv /tmp/scripts/*.groovy /var/lib/jenkins/init.groovy.d/
+mv /tmp/config/jenkins /etc/sysconfig/jenkins
+chmod +x /tmp/config/install-plugins.sh
+bash /tmp/config/install-plugins.sh
 service jenkins start


### PR DESCRIPTION
## Resolve packer build error No such file
Resolve packer build error No such file during the provisioners execution of the setup.sh by pointing to the right subdirectories instead of directly to /tmp/
``` shell
==> amazon-ebs: Configure Jenkins
==> amazon-ebs: mv: cannot stat ‘/tmp/*.groovy’: No such file or directory
==> amazon-ebs: mv: cannot stat ‘/tmp/jenkins’: No such file or directory
==> amazon-ebs: chmod: cannot access ‘/tmp/install-plugins.sh’: No such file or directory
==> amazon-ebs: bash: /tmp/install-plugins.sh: No such file or directory
```
## Solution proposed
Fix the source of the file move command in the _setup.sh_ by using to the right subdirectories instead of directly to /tmp/

## issue loading Jenkins Dashboard when running a standalone EC2 Instance
``` shell
java.lang.RuntimeException: /var/lib/jenkins/init.groovy.d/basic-security.groovy can not be read. Check the read permission of the file "/var/lib/jenkins/init.groovy.d/basic-security.groovy" (/var/lib/jenkins/init.groovy.d/basic-security.groovy).
```
## Solution Proposed
Make the user jenkins owner of the directory _/var/lib/jenkins/init.groovy.d_ during the _setup.sh_

## Book Location 
Listing 4.13

## requester comment
The code was tested a few times and resolve all the issues mentionned in this request.