### PR TITLE
add Installing Amazon Linux Extras

### DIFF
--- a/chapter4/distributed/master/setup.sh
+++ b/chapter4/distributed/master/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "Installing Amazon Linux extras"
+amazon-linux-extras install epel -y
+
 echo "Install Jenkins stable release"
 yum remove -y java
 yum install -y java-1.8.0-openjdk


### PR DESCRIPTION
Fix error from Chapter 4 Jenkins Master Packer build.
- add amazon-linux-extras install epel -y to setup.sh file
-resolves Error: Package: jenkins-2.308-1.1.noarch (Jenkins) Requires: daemonize